### PR TITLE
Adding support to show stylistic set names in the OpenTypeControlsView

### DIFF
--- a/Lib/defconAppKit/controls/openTypeControlsView.py
+++ b/Lib/defconAppKit/controls/openTypeControlsView.py
@@ -99,6 +99,10 @@ class OpenTypeControlsView(vanilla.ScrollView):
             del self._controlGroup.gposTitle
         if hasattr(self._controlGroup, "gsubTitle"):
             del self._controlGroup.gsubTitle
+        # stylistic set names
+        if hasattr(font, "stylisticSetNames"):
+            stylisticSetNames = font.stylisticSetNames
+        else: stylisticSetNames = {}
         # GSUB
         top = self._dynamicTop
         if font is None:
@@ -121,6 +125,13 @@ class OpenTypeControlsView(vanilla.ScrollView):
                 setattr(self._controlGroup, attr, obj)
                 self._gsubAttributes[attr] = tag
                 top += 20
+                # stylistic set name
+                if tag in stylisticSetNames:
+                    attr = "ssName_%s" % tag
+                    setName = stylisticSetNames[tag]
+                    obj = vanilla.TextBox((26, top, -10, 13), setName, sizeStyle="mini")
+                    setattr(self._controlGroup, attr, obj)
+                    top += 13
             top += 10
         # GPOS
         if font is None:


### PR DESCRIPTION
Adding support to show stylistic set names in the OpenTypeControlsView.

It checks first to see if the Compositor font has a stylisticSetNames attribute (a pull request for this feature was just sent), and if it does it will add a small line with the feature name below the check box.
