### PR TITLE
Adds a flipped=False flag to tools.drawing.drawFontVerticalMetrics()

### DIFF
--- a/Lib/defconAppKit/tools/drawing.py
+++ b/Lib/defconAppKit/tools/drawing.py
@@ -150,7 +150,7 @@ def drawTextAtPoint(text, pt, scale, attributes={}, xAlign="left", yAlign="botto
 
 # Vertical Metrics
 
-def drawFontVerticalMetrics(glyph, scale, rect, drawLines=True, drawText=True, color=None, backgroundColor=None):
+def drawFontVerticalMetrics(glyph, scale, rect, drawLines=True, drawText=True, color=None, backgroundColor=None, flipped=False):
     font = glyph.font
     if font is None:
         return

--- a/Lib/defconAppKit/tools/textSplitter.py
+++ b/Lib/defconAppKit/tools/textSplitter.py
@@ -21,6 +21,10 @@ def splitText(text, cmap, fallback=".notdef"):
     ['aacute', 'bbreve']
     >>> splitText("/aacute /bbreve", {})
     ['aacute', 'bbreve']
+    >>> splitText("/cmb:dieresis /cmb:acute", {})
+    ['cmb:dieresis', 'cmb:acute']
+    >>> splitText("/cmb-dieresis /cmb-acute", {})
+    ['cmb-dieresis', 'cmb-acute']
 
     - Test character input
     >>> splitText("*.", {})


### PR DESCRIPTION
This one may have gotten lost somehow. It was part of older releases.