### PR TITLE
Fixing a traceback in openTypeControlsView when updating the interface

### DIFF
--- a/Lib/defconAppKit/controls/openTypeControlsView.py
+++ b/Lib/defconAppKit/controls/openTypeControlsView.py
@@ -133,8 +133,12 @@ class OpenTypeControlsView(vanilla.ScrollView):
                 if tag in stylisticSetNames:
                     attr = "ssName_%s" % tag
                     setName = stylisticSetNames[tag]
-                    obj = vanilla.TextBox((26, top, -10, 13), setName, sizeStyle="mini")
-                    setattr(self._controlGroup, attr, obj)
+                    if hasattr(self._controlGroup, attr):
+                        obj = getattr(self._controlGroup, attr)
+                        obj.set(setName)
+                    else:
+                        obj = vanilla.TextBox((26, top, -10, 13), setName, sizeStyle="mini")
+                        setattr(self._controlGroup, attr, obj)
                     self._featureNames[attr] = setName
                     top += 13
             top += 10


### PR DESCRIPTION
Fixes a bug with the display of Stylistic Set names in the openTypeControlsView.

When updating the features, instead of replacing the Vanilla control with one that has a new name (which results in a traceback), check to see if the control exists and simply update the name. Otherwise, create a new control if one hadn't existed.