### PR TITLE
Fixes a traceback for Python 3 in _breakCycles in the FontList object

### DIFF
--- a/Lib/defconAppKit/controls/fontList.py
+++ b/Lib/defconAppKit/controls/fontList.py
@@ -178,8 +178,8 @@ class FontList(vanilla.List):
 
     def _breakCycles(self):
         for font in self._wrappedListItems.keys():
-            del self._wrappedListItems[font]
             self._unsubscribeFromFont(font)
+        self._wrappedListItems.clear()
         self._placard = None
         self._placardSortOptions = {}
         super(FontList, self)._breakCycles()


### PR DESCRIPTION
This appears to fix a traceback that I get with Python 3 (in RoboFont 3 beta)

```
File "/defconAppKit/controls/fontList.py", line 180, in _breakCycles
  for font in self._wrappedListItems.keys():
RuntimeError: dictionary changed size during iteration
```
